### PR TITLE
Add basic fossa workflow

### DIFF
--- a/.github/fossa.yml
+++ b/.github/fossa.yml
@@ -1,0 +1,25 @@
+name: FOSSA CLI Analysis
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+  workflow_dispatch:
+
+jobs:
+  fossa:
+    runs-on: ubuntu-latest
+    env:
+      FOSSA_API_KEY: ${{secrets.FOSSA_API_KEY}}
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v3
+  
+      - name: Running FOSSA CLI
+        run: |
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
+          fossa --version
+          fossa analyze


### PR DESCRIPTION
This workflow retrieves the FOSSA binary via curl. It runs `fossa analyze`, which will scan the repository with the default policy and submit results to app.fossa.com. It does not block PRs if issues are found. However, if `fossa analyze` does not execute with a successful exit code, the workflow will fail and will block the PR. 