### PR TITLE
newrelic-java-examples

### DIFF
--- a/.github/workflows/fossa-scala.yml
+++ b/.github/workflows/fossa-scala.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download newrelic.jar
-        if: ${{ github.repository == 'newrelic-java-examples' }}
+        if: ${{ github.repository == 'newrelic-csec/newrelic-java-examples' }}
         run: |
           mkdir newrelic-java-agent/scala/segment-api-synchronous/libs
           curl https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic.jar --output newrelic-java-agent/scala/segment-api-synchronous/libs/newrelic.jar

--- a/.github/workflows/fossa-scala.yml
+++ b/.github/workflows/fossa-scala.yml
@@ -18,15 +18,10 @@ jobs:
     strategy:
       fail-fast: false
 
-    steps:  
-      - uses: actions/checkout@v4
-      - name: Setup JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 8 
+    steps:
+      - uses: actions/checkout@v3
       - id: fossa-list-targets
-        name: Run fossa list-targets 
+        name: Run fossa list-targets
         run: |
           curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
           export LIST_TARGETS_OUT_FILE=${{ runner.temp }}/list-targets_out.txt
@@ -82,6 +77,6 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/$ORG/properties/values \
             -d '{"repository_names":["'"${REPO##*/}"'"],"properties":[{"property_name":"fossaAnalyzeResult","value":"'"${{ steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT }}"'"}]}'
-      - name: Exit 
+      - name: Exit
         if: ${{ steps.fossa-list-targets.outputs.HAS_FOSSA_TARGETS == 'Error' || steps.fossa-analyze.outputs.FOSSA_ANALYZE_RESULT == 'Error' }}
         run: exit 1

--- a/.github/workflows/fossa-scala.yml
+++ b/.github/workflows/fossa-scala.yml
@@ -20,6 +20,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Download newrelic.jar
+        if: ${{ github.repository == 'newrelic-java-examples' }}
+        run: |
+          mkdir newrelic-java-agent/scala/segment-api-synchronous/libs
+          curl https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic.jar --output newrelic-java-agent/scala/segment-api-synchronous/libs/newrelic.jar
       - id: fossa-list-targets
         name: Run fossa list-targets
         run: |


### PR DESCRIPTION
If the repo is newrelic-java-examples, download the current newrelic.jar. This allows FOSSA to succeessfully run sbt.